### PR TITLE
Oracle compability

### DIFF
--- a/lib/acts_as_taggable_on/taggable/collection.rb
+++ b/lib/acts_as_taggable_on/taggable/collection.rb
@@ -161,7 +161,7 @@ module ActsAsTaggableOn::Taggable
       end
 
       def tag_scope_joins(tag_scope, tagging_scope)
-        tag_scope = tag_scope.joins("JOIN (#{safe_to_sql(tagging_scope)}) AS #{ActsAsTaggableOn::Tagging.table_name} ON #{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.id")
+        tag_scope = tag_scope.joins("JOIN (#{safe_to_sql(tagging_scope)}) #{ActsAsTaggableOn::Tagging.table_name} ON #{ActsAsTaggableOn::Tagging.table_name}.tag_id = #{ActsAsTaggableOn::Tag.table_name}.id")
         tag_scope.extending(CalculationMethods)
       end
     end


### PR DESCRIPTION
Oracle can not handle the AS in the JOIN statement and fails with OCIError: ORA-00905: missing keyword
Removed AS from tag_scope_join JOIN statement in order to make the gem compatible with oracle databases